### PR TITLE
Bump yala to v0.9.0

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -12,6 +12,8 @@ import (
 	"github.com/jacekolszak/yala/logger"
 )
 
+var Logger logger.Global
+
 func StartLoans(ctx context.Context, s Store) (loans *SynchronizedLoans, done <-chan struct{}, err error) {
 	loans, err = loadState(ctx, s)
 	if err != nil {
@@ -45,11 +47,11 @@ func loadState(ctx context.Context, s Store) (*SynchronizedLoans, error) {
 	snapshot := service.Snapshot{}
 	version, err := s.ReadLatest(&snapshot)
 	if store.IsVersionNotFound(err) {
-		logger.WithError(ctx, err).Warn("No snapshot found")
+		Logger.WithError(ctx, err).Warn("No snapshot found")
 	} else if err != nil {
 		return nil, err
 	} else {
-		logger.With(ctx, "version", version).Info("Snapshot loaded")
+		Logger.With(ctx, "version", version).Info("Snapshot loaded")
 	}
 
 	loans := service.FromSnapshot(snapshot)
@@ -60,9 +62,9 @@ func loadState(ctx context.Context, s Store) (*SynchronizedLoans, error) {
 }
 
 func saveState(ctx context.Context, loans *SynchronizedLoans, s Store) {
-	logger.Info(ctx, "Saving loans.Service state")
+	Logger.Info(ctx, "Saving loans.Service state")
 	snapshot := loans.Snapshot()
 	if err := s.Write(&snapshot); err != nil {
-		logger.WithError(ctx, err).Error("error saving state")
+		Logger.WithError(ctx, err).Error("error saving state")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/jacekolszak/deebee v0.5.0
-	github.com/jacekolszak/yala v0.7.0
+	github.com/jacekolszak/yala v0.9.0
 )

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0L
 github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac/go.mod h1:cOaXtrgN4ScfRrD9Bre7U1thNq5RtJ8ZoP4iXVGRj6o=
 github.com/jacekolszak/deebee v0.5.0 h1:yhaXU79EE8AKYBZXX0HG2Gfk6JQ/FvfFtnS2RZJe2tQ=
 github.com/jacekolszak/deebee v0.5.0/go.mod h1:QqXMs3gDNzXYDfdlwpL8rXNsOmTtVlxcQVWU+NT8JH0=
-github.com/jacekolszak/yala v0.7.0 h1:xMKMmoZ98abdkIxbQd4FGj5e1dFC/g1dS2kPbD1ukWg=
-github.com/jacekolszak/yala v0.7.0/go.mod h1:qjJ0qAI/5E2ki6jDJ8cN/G11IdH52zBXyK0DsZgaS5A=
+github.com/jacekolszak/yala v0.9.0 h1:cgyPXRXrmpDsB5eR84JLdCqnt+USNk3TYd77XyhetPc=
+github.com/jacekolszak/yala v0.9.0/go.mod h1:qjJ0qAI/5E2ki6jDJ8cN/G11IdH52zBXyK0DsZgaS5A=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -28,7 +28,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.26.1/go.mod h1:/wSSJWX7lVrsOwlbyTRSOJvqRlc+WjWlfes+CiJ+tmc=
-github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -63,7 +62,6 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 h1:foEbQz/B0Oz6YIqu/69kfXPYeFQAuuMYFkjaqXzl5Wo=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/web/pay.go
+++ b/web/pay.go
@@ -11,6 +11,8 @@ import (
 	"github.com/jacekolszak/yala/logger"
 )
 
+var Logger logger.Global
+
 type payLoan struct {
 	loans Loans
 }
@@ -31,10 +33,10 @@ func (h payLoan) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	activeLoan, err := h.loans.GetActiveLoan(userID)
 	if err != nil {
 		writer.WriteHeader(500)
-		logger.WithError(ctx, err).Error("error getting active loan")
+		Logger.WithError(ctx, err).Error("error getting active loan")
 		return
 	}
 
-	logger.Info(ctx, "Loan paid off")
+	Logger.Info(ctx, "Loan paid off")
 	_, _ = fmt.Fprintln(writer, "Amount remaining:", activeLoan.AmountRemaining)
 }

--- a/web/take.go
+++ b/web/take.go
@@ -6,8 +6,6 @@ package web
 import (
 	"net/http"
 	"strconv"
-
-	"github.com/jacekolszak/yala/logger"
 )
 
 type takeLoan struct {
@@ -28,6 +26,6 @@ func (h takeLoan) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	logger.Info(ctx, "New loan taken")
+	Logger.Info(ctx, "New loan taken")
 	writer.WriteHeader(201)
 }

--- a/web/web.go
+++ b/web/web.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 
 	"github.com/jacekolszak/deebee-loans/service"
-	"github.com/jacekolszak/yala/logger"
 )
 
 func ListenAndServe(ctx context.Context, loans Loans) error {
@@ -20,7 +19,7 @@ func ListenAndServe(ctx context.Context, loans Loans) error {
 	server := &http.Server{Addr: ":8080", Handler: mux}
 	shutdownServerOnceDone(ctx, server)
 
-	logger.With(ctx, "address", server.Addr).Info("Starting web server")
+	Logger.With(ctx, "address", server.Addr).Info("Starting web server")
 	return server.ListenAndServe()
 }
 
@@ -35,9 +34,9 @@ func shutdownServerOnceDone(ctx context.Context, server *http.Server) {
 		for {
 			select {
 			case <-ctx.Done():
-				logger.Info(ctx, "Shutting down web server")
+				Logger.Info(ctx, "Shutting down web server")
 				if err := server.Shutdown(context.Background()); err != nil {
-					logger.WithError(ctx, err).Error("Problem shutting down the server")
+					Logger.WithError(ctx, err).Error("Problem shutting down the server")
 				}
 				return
 			}


### PR DESCRIPTION
This version introduces breaking changes. Yala allows now to define your own global loggers, which are more elastic than single shared global logger.